### PR TITLE
fix: Cancel cocktail minigame bound to Q

### DIFF
--- a/Assets/Scripts/Interactables/CocktailMiniGame.cs
+++ b/Assets/Scripts/Interactables/CocktailMiniGame.cs
@@ -80,16 +80,16 @@ namespace FMS.TapperRedone.Interactables
         // Update is called once per frame
         void Update()
         {
-            if (isMiniGameActive)
-                DetectPlayerInput();
-
             // Quit detection is always checked
             if (Input.GetButtonDown(QuitKey))
             {
                 EndCocktailMiniGame(false);
             }
 
-
+            if (isMiniGameActive)
+            {
+                DetectPlayerInput();
+            }
         }
 
         //changes gamestate to cocktail minigame

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -106,7 +106,7 @@ InputManager:
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: backspace
+    positiveButton: q
     altNegativeButton: 
     altPositiveButton: 
     gravity: 3


### PR DESCRIPTION
Was bound to backspace, set it for Q instead.